### PR TITLE
Corrected more timezone date overflow issues.

### DIFF
--- a/src/adzone/migrations/0002_auto__add_field_adbase_start_showing__add_field_adbase_stop_showing.py
+++ b/src/adzone/migrations/0002_auto__add_field_adbase_start_showing__add_field_adbase_stop_showing.py
@@ -3,20 +3,21 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+
+# Use a datetime a few days before the max to that timezone changes don't
+# cause an OverflowError.
+MAX_DATETIME = datetime.datetime.max - datetime.timedelta(days=2)
 try:
     from django.utils.timezone import now, make_aware, utc
 except ImportError:
     now = datetime.datetime.now
-    make_aware = None
+else:
+    MAX_DATETIME = make_aware(MAX_DATETIME, utc)
 
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        if make_aware is None:
-            max_dt = datetime.datetime.max
-        else:
-            max_dt = make_aware(datetime.datetime.max, utc)
         # Adding field 'AdBase.start_showing'
         db.add_column('adzone_adbase', 'start_showing',
                       self.gf('django.db.models.fields.DateTimeField')(default=now),
@@ -24,7 +25,7 @@ class Migration(SchemaMigration):
 
         # Adding field 'AdBase.stop_showing'
         db.add_column('adzone_adbase', 'stop_showing',
-                      self.gf('django.db.models.fields.DateTimeField')(default=max_dt),
+                      self.gf('django.db.models.fields.DateTimeField')(default=MAX_DATETIME),
                       keep_default=False)
 
 
@@ -45,7 +46,7 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'since': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'start_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 31, 0, 0)'}),
+            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 29, 0, 0)'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),

--- a/src/adzone/migrations/0003_copy_enabled.py
+++ b/src/adzone/migrations/0003_copy_enabled.py
@@ -3,28 +3,21 @@ import datetime
 from south.db import db
 from south.v2 import DataMigration
 from django.db import models
+
 try:
-    from django.utils.timezone import now, make_aware, utc
+    from django.utils.timezone import now
 except ImportError:
     now = datetime.datetime.now
-    make_aware = None
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        "Write your forwards methods here."
+        # The AdBase objects currently *all* start showing at "now"-ish
+        # and stop showing at max_dt. So we just need to update the disabled
+        # ads to stop showing "now"-ish.
         AdBase = orm['adzone.adbase']
-        if make_aware is None:
-            max_dt = datetime.datetime.max
-        else:
-            max_dt = make_aware(datetime.datetime.max, utc)
-
-        ads_enabled = AdBase.objects.filter(enabled=True)
-        ads_enabled.update(start_showing=now(),
-                           stop_showing=max_dt)
         ads_disabled = AdBase.objects.filter(enabled=False)
-        ads_disabled.update(start_showing=now(),
-                            stop_showing=now())
+        ads_disabled.update(stop_showing=now())
 
     def backwards(self, orm):
         "Write your backwards methods here."
@@ -45,7 +38,7 @@ class Migration(DataMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'since': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'start_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 31, 0, 0)'}),
+            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 29, 0, 0)'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),

--- a/src/adzone/migrations/0004_auto__del_field_adbase_enabled.py
+++ b/src/adzone/migrations/0004_auto__del_field_adbase_enabled.py
@@ -27,7 +27,7 @@ class Migration(SchemaMigration):
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'since': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             'start_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 31, 0, 0)'}),
+            'stop_showing': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(9999, 12, 29, 0, 0)'}),
             'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
             'url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),

--- a/src/adzone/models.py
+++ b/src/adzone/models.py
@@ -13,6 +13,16 @@ from django.utils.translation import ugettext_lazy as _
 
 from adzone.managers import AdManager
 
+# Use a datetime a few days before the max to that timezone changes don't
+# cause an OverflowError.
+MAX_DATETIME = datetime.datetime.max - datetime.timedelta(days=2)
+try:
+    from django.utils.timezone import now, make_aware, utc
+except ImportError:
+    now = datetime.datetime.now
+else:
+    MAX_DATETIME = make_aware(MAX_DATETIME, utc)
+
 
 class Advertiser(models.Model):
     """ A Model for our Advertiser.  """
@@ -75,9 +85,9 @@ class AdBase(models.Model):
     updated = models.DateTimeField(verbose_name=_(u'Updated'), auto_now=True)
 
     start_showing = models.DateTimeField(verbose_name=_(u'Start showing'),
-                                         default=datetime.datetime.now)
+                                         default=now)
     stop_showing = models.DateTimeField(verbose_name=_(u'Stop showing'),
-                                        default=datetime.datetime.max)
+                                        default=MAX_DATETIME)
 
     # Relations
     advertiser = models.ForeignKey(Advertiser, verbose_name=_("Ad Provider"))


### PR DESCRIPTION
Turns out that (if pytz is installed) some extra datetime overflow issues with migrations show up.

This commit drops the MAX_DATETIME that the code uses to two days prior to datetime.max. This resolves the issues by putting the "end of time" out of range of any timezone changes.
