### PR TITLE
Reduce number of queries required per adzone tag.

### DIFF
--- a/src/adzone/managers.py
+++ b/src/adzone/managers.py
@@ -16,19 +16,15 @@ class AdManager(models.Manager):
         and ``ad_zone``.
         If ``ad_category`` is None, the ad will be category independent.
         """
+        qs = self.get_query_set().filter(start_showing__lte=now(),
+                                         stop_showing__gte=now(),
+                                         zone__slug=ad_zone
+                                         ).select_related('textad',
+                                                          'bannerad')
+        if ad_category:
+            qs = qs.filter(category__slug=ad_category)
         try:
-            if ad_category:
-                ad = self.get_query_set().filter(
-                    start_showing__lte=now(),
-                    stop_showing__gte=now(),
-                    category__slug=ad_category,
-                    zone__slug=ad_zone
-                ).order_by('?')[0]
-            else:
-                ad = self.get_query_set().filter(
-                    start_showing__lte=now(),
-                    stop_showing__gte=now(),
-                    zone__slug=ad_zone).order_by('?')[0]
+            ad = qs.order_by('?')[0]
         except IndexError:
             return None
         return ad


### PR DESCRIPTION
Right now, using `{% random_zone_ad %}` or `{% random_category_ad %}` adds three queries to the page: one for the AdBase instance, one to check whether a TextAd instance exists, and one to check whether a BannerAd instance exists.

By adding a .select_related() call to AdManager.get_random_ad(), we can reduce the number of queries down to one.
