### PR TITLE
Updated django.conf.urls.defaults import.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     install_requires=[
-        'setuptools',
+        'django>=1.4',
     ],
     include_package_data=True,
 )

--- a/src/adzone/urls.py
+++ b/src/adzone/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 
 from adzone.views import ad_view
 


### PR DESCRIPTION
Resolves #26.

This also means that django-adzone will require django 1.4+, so I updated setup.py to reflect that.
